### PR TITLE
Fixes #423 pop workflow can be initialized with simulationSetDescriptor

### DIFF
--- a/R/population-workflow.R
+++ b/R/population-workflow.R
@@ -32,18 +32,21 @@ PopulationWorkflow <- R6::R6Class(
     #' @param workflowFolder path of the output folder created or used by the Workflow.
     #' @param createWordReport logical of option for creating Markdwon-Report only but not a Word-Report.
     #' @param watermark displayed watermark in every plot background
+    #' @param simulationSetDescriptor character Descriptor of simulation sets indicated in reports
     #' @return A new `PopulationWorkflow` object
     #' @import ospsuite
     initialize = function(workflowType,
                               simulationSets,
                               workflowFolder,
                               createWordReport = TRUE,
-                              watermark = NULL) {
+                              watermark = NULL,
+                          simulationSetDescriptor = NULL) {
       super$initialize(
         simulationSets = simulationSets,
         workflowFolder = workflowFolder,
         createWordReport = createWordReport,
-        watermark = watermark
+        watermark = watermark,
+        simulationSetDescriptor = simulationSetDescriptor
       )
 
       validateIsOfType(c(simulationSets), "PopulationSimulationSet")

--- a/man/PopulationWorkflow.Rd
+++ b/man/PopulationWorkflow.Rd
@@ -69,7 +69,8 @@ Create a new `PopulationWorkflow` object.
   simulationSets,
   workflowFolder,
   createWordReport = TRUE,
-  watermark = NULL
+  watermark = NULL,
+  simulationSetDescriptor = NULL
 )}\if{html}{\out{</div>}}
 }
 
@@ -85,6 +86,8 @@ Create a new `PopulationWorkflow` object.
 \item{\code{createWordReport}}{logical of option for creating Markdwon-Report only but not a Word-Report.}
 
 \item{\code{watermark}}{displayed watermark in every plot background}
+
+\item{\code{simulationSetDescriptor}}{character Descriptor of simulation sets indicated in reports}
 }
 \if{html}{\out{</div>}}
 }


### PR DESCRIPTION
Before the method was available with new() for mean model workflow
and for both workflows using setSimulationDescriptor()