### PR TITLE
Fixes #583 use loadFromCache when possible

### DIFF
--- a/R/qualification-comparison-time-profile.R
+++ b/R/qualification-comparison-time-profile.R
@@ -87,7 +87,7 @@ addOutputToComparisonTimeProfile <- function(outputMapping, simulationDuration, 
     project = outputMapping$Project,
     simulation = outputMapping$Simulation
   )
-  simulation <- ospsuite::loadSimulation(simulationFile)
+  simulation <- ospsuite::loadSimulation(simulationFile, loadFromCache = TRUE)
   simulationResults <- ospsuite::importResultsFromCSV(simulation, simulationResultsFile)
   # Get and convert output path values into display unit
   simulationQuantity <- ospsuite::getQuantity(outputMapping$Output, simulation)

--- a/R/qualification-gof.R
+++ b/R/qualification-gof.R
@@ -105,7 +105,7 @@ getGOFDataForMapping <- function(outputMapping, configurationPlan, axesUnits, lo
     project = outputMapping$Project,
     simulation = outputMapping$Simulation
   )
-  simulation <- ospsuite::loadSimulation(simulationFile)
+  simulation <- ospsuite::loadSimulation(simulationFile, loadFromCache = TRUE)
   simulationResults <- ospsuite::importResultsFromCSV(simulation, simulationResultsFile)
   # Get and convert output path values into display unit
   simulationQuantity <- ospsuite::getQuantity(outputMapping$Output, simulation)

--- a/R/qualification-pk-ratio.R
+++ b/R/qualification-pk-ratio.R
@@ -221,7 +221,8 @@ getQualificationPKRatioData <- function(pkRatioPlan, configurationPlan, logFolde
 getPKRatioForMapping <- function(pkRatioMapping, pkParameterNames, configurationPlan, logFolder) {
   # Load required inputs
   simulation <- ospsuite::loadSimulation(
-    configurationPlan$getSimulationPath(project = pkRatioMapping$Project, simulation = pkRatioMapping$Simulation)
+    configurationPlan$getSimulationPath(project = pkRatioMapping$Project, simulation = pkRatioMapping$Simulation),
+    loadFromCache = TRUE
   )
   pkAnalyses <- ospsuite::importPKAnalysesFromCSV(
     filePath = configurationPlan$getPKAnalysisResultsPath(project = pkRatioMapping$Project, simulation = pkRatioMapping$Simulation),

--- a/R/qualification-time-profile.R
+++ b/R/qualification-time-profile.R
@@ -24,7 +24,7 @@ plotQualificationTimeProfiles <- function(configurationPlan,
       simulation = timeProfilePlan$Simulation
     )
 
-    simulation <- ospsuite::loadSimulation(simulationFile)
+    simulation <- ospsuite::loadSimulation(simulationFile, loadFromCache = TRUE)
     simulationResults <- ospsuite::importResultsFromCSV(simulation, simulationResultsFile)
 
     # Get axes properties (with scale, limits and display units)

--- a/R/utilities-calculate-pk-parameters.R
+++ b/R/utilities-calculate-pk-parameters.R
@@ -47,7 +47,7 @@ plotMeanPKParameters <- function(structureSet,
   pkParametersData <- NULL
 
   re.tStoreFileMetadata(access = "read", filePath = structureSet$simulationSet$simulationFile)
-  simulation <- loadSimulationWithUpdatedPaths(structureSet$simulationSet)
+  simulation <- loadSimulationWithUpdatedPaths(structureSet$simulationSet, loadFromCache = TRUE)
 
   re.tStoreFileMetadata(access = "read", filePath = structureSet$pkAnalysisResultsFileNames)
   pkAnalyses <- ospsuite::importPKAnalysesFromCSV(
@@ -157,7 +157,7 @@ plotPopulationPKParameters <- function(structureSets,
   # Use first structure set as reference
   yParameters <- yParameters %||% structureSets[[1]]$simulationSet$outputs
   # Get first simulation, in case mol weight is needed
-  simulation <- loadSimulationWithUpdatedPaths(structureSets[[1]]$simulationSet)
+  simulation <- loadSimulationWithUpdatedPaths(structureSets[[1]]$simulationSet, loadFromCache = TRUE)
   simulationSetDescriptor <- structureSets[[1]]$simulationSetDescriptor
 
   pkRatioTableAcrossPopulations <- NULL
@@ -569,7 +569,7 @@ vpcParameterPlot <- function(data,
 getPKParametersAcrossPopulations <- function(structureSets) {
   pkParametersTableAcrossPopulations <- NULL
   for (structureSet in structureSets) {
-    simulation <- loadSimulationWithUpdatedPaths(structureSet$simulationSet)
+    simulation <- loadSimulationWithUpdatedPaths(structureSet$simulationSet, loadFromCache = TRUE)
     population <- loadWorkflowPopulation(structureSet$simulationSet)
     pkAnalyses <- ospsuite::importPKAnalysesFromCSV(
       structureSet$pkAnalysisResultsFileNames,

--- a/R/utilities-demography.R
+++ b/R/utilities-demography.R
@@ -224,7 +224,7 @@ getDemographyAcrossPopulations <- function(structureSets) {
   for (structureSet in structureSets)
   {
     population <- loadWorkflowPopulation(structureSet$simulationSet)
-    simulation <- ospsuite::loadSimulation(structureSet$simulationSet$simulationFile)
+    simulation <- ospsuite::loadSimulation(structureSet$simulationSet$simulationFile, loadFromCache = TRUE)
     populationTable <- getPopulationAsDataFrame(population, simulation)
 
     fullDemographyTable <- cbind.data.frame(

--- a/R/utilities-goodness-of-fit.R
+++ b/R/utilities-goodness-of-fit.R
@@ -26,7 +26,7 @@ plotMeanGoodnessOfFit <- function(structureSet,
 
   # Load observed and simulated data
   re.tStoreFileMetadata(access = "read", filePath = structureSet$simulationSet$simulationFile)
-  simulation <- loadSimulationWithUpdatedPaths(structureSet$simulationSet)
+  simulation <- loadSimulationWithUpdatedPaths(structureSet$simulationSet, loadFromCache = TRUE)
 
   re.tStoreFileMetadata(access = "read", filePath = structureSet$simulationResultFileNames)
   simulationResult <- ospsuite::importResultsFromCSV(simulation, structureSet$simulationResultFileNames)
@@ -239,7 +239,7 @@ plotPopulationGoodnessOfFit <- function(structureSet,
 
   # Load observed and simulated data
   re.tStoreFileMetadata(access = "read", filePath = structureSet$simulationSet$simulationFile)
-  simulation <- loadSimulationWithUpdatedPaths(structureSet$simulationSet)
+  simulation <- loadSimulationWithUpdatedPaths(structureSet$simulationSet, loadFromCache = TRUE)
 
   re.tStoreFileMetadata(access = "read", filePath = structureSet$simulationResultFileNames)
   simulationResult <- ospsuite::importResultsFromCSV(simulation, structureSet$simulationResultFileNames)

--- a/R/utilities-mass-balance.R
+++ b/R/utilities-mass-balance.R
@@ -14,7 +14,7 @@ plotMeanMassBalance <- function(structureSet,
                                 logFolder = getwd(),
                                 settings = NULL) {
   re.tStoreFileMetadata(access = "read", filePath = structureSet$simulationSet$simulationFile)
-  simulation <- loadSimulationWithUpdatedPaths(structureSet$simulationSet)
+  simulation <- loadSimulationWithUpdatedPaths(structureSet$simulationSet, loadFromCache = TRUE)
 
   # Get drug mass to perform the drugmass normalized plot
   applications <- ospsuite::getContainer("Applications", simulation)

--- a/R/utilities-sensitivity-analysis.R
+++ b/R/utilities-sensitivity-analysis.R
@@ -504,7 +504,7 @@ plotMeanSensitivity <- function(structureSet,
                                 logFolder = getwd(),
                                 settings) {
   re.tStoreFileMetadata(access = "read", filePath = structureSet$simulationSet$simulationFile)
-  simulation <- loadSimulationWithUpdatedPaths(structureSet$simulationSet)
+  simulation <- loadSimulationWithUpdatedPaths(structureSet$simulationSet, loadFromCache = TRUE)
 
   re.tStoreFileMetadata(access = "read", filePath = structureSet$sensitivityAnalysisResultsFileNames)
   saResults <- ospsuite::importSensitivityAnalysisResultsFromCSV(
@@ -636,7 +636,7 @@ plotPopulationSensitivity <- function(structureSets,
     sensitivityResultsFolder <- file.path(structureSet$workflowFolder, structureSet$sensitivityAnalysisResultsFolder)
 
     re.tStoreFileMetadata(access = "read", filePath = structureSet$simulationSet$simulationFile)
-    simulation <- loadSimulationWithUpdatedPaths(structureSet$simulationSet)
+    simulation <- loadSimulationWithUpdatedPaths(structureSet$simulationSet, loadFromCache = TRUE)
 
     re.tStoreFileMetadata(access = "read", filePath = structureSet$popSensitivityAnalysisResultsIndexFile)
     if (!(file.exists(structureSet$popSensitivityAnalysisResultsIndexFile))) next


### PR DESCRIPTION
The RE function loadSimulationWithUpdated path does not add to cache and is used for absorption. So there should not be any side effect when including loadFromCache