### PR TITLE
fix DDI axis labels and legend positions

### DIFF
--- a/R/qualification-ddi.R
+++ b/R/qualification-ddi.R
@@ -236,7 +236,11 @@ generateDDIQualificationDDIPlot <- function(ddiPlotData) {
 
   ddiPlotConfiguration <- getPlotConfigurationFromPlan(plotProperties = ddiPlotData$plotSettings,
                                                        plotType = "DDIRatio",
-                                                       legendPosition = reEnv$theme$background$legendPosition)
+                                                       legendPosition = tlf::LegendPositions$outsideRight)
+
+  #Set axes labels
+  ddiPlotConfiguration$labels$xlabel$text <- ddiPlotData$axesSettings$X$label
+  ddiPlotConfiguration$labels$ylabel$text <- ddiPlotData$axesSettings$Y$label
 
   # Set line color and type
   ddiPlotConfiguration$lines$color <- "black"
@@ -280,13 +284,6 @@ generateDDIQualificationDDIPlot <- function(ddiPlotData) {
 
   # Force legend to be only one column to maintain plot panel width, and left-justify legend entries
   qualificationDDIPlot <- qualificationDDIPlot + ggplot2::guides(col = guide_legend(ncol = 1, label.hjust = 0))
-
-  xlabel <- paste(ddiPlotData$axesSettings$X$label)
-  ylabel <- paste(ddiPlotData$axesSettings$Y$label)
-
-  qualificationDDIPlot <- qualificationDDIPlot + ggplot2::xlab(xlabel) + ggplot2::ylab(ylabel)
-
-
 
   return(qualificationDDIPlot)
 }
@@ -349,7 +346,7 @@ getDDISection <- function(dataframe, metadata, sectionID, idPrefix, captionSuffi
         sectionId = sectionID,
         plot = ddiPlot,
         plotCaption = ospsuite.utils::ifNotNull(
-          inputToCheck = captionSuffix,
+          condition = captionSuffix,
           outputIfNotNull = paste(metadata$title, captionSuffix, sep = " - "),
           outputIfNull = metadata$title
         )

--- a/R/utilities-plots.R
+++ b/R/utilities-plots.R
@@ -89,7 +89,7 @@ autoAxesTicksFromLimits <- function(limits) {
 #' @return A `PlotConfiguration` object
 #' @importFrom ospsuite.utils %||%
 #' @keywords internal
-getPlotConfigurationFromPlan <- function(plotProperties, plotType = NULL, legendPosition = reEnv$theme$background$legendPosition) {
+getPlotConfigurationFromPlan <- function(plotProperties, plotType = NULL, legendPosition = NULL) {
   # Define the appropriate configuration from plotType
   # by creating expression: "tlf::<plotType>PlotCOnfiguration$new()"
   plotConfiguration <- eval(parse(text = paste0("tlf::", plotType, "PlotConfiguration$new()")))
@@ -106,6 +106,10 @@ getPlotConfigurationFromPlan <- function(plotProperties, plotType = NULL, legend
   plotConfiguration$yAxis$font$size <- reEnv$fontScaleFactor*(fonts$AxisSize %||% plotConfiguration$yAxis$font$size)
   plotConfiguration$legend$font$size <- reEnv$fontScaleFactor*(fonts$LegendSize %||% plotConfiguration$legend$font$size)
   plotConfiguration$background$watermark$font$size <- reEnv$fontScaleFactor*(fonts$WatermarkSize %||% plotConfiguration$background$watermark$font$size)
+
+  #Set legend position
+  ospsuite.utils::validateIsIncluded(values = legendPosition, parentValues = tlf::LegendPositions, nullAllowed = TRUE)
+  plotConfiguration$legend$position <- legendPosition %||% reEnv$theme$background$legendPosition
 
   # If chart size is defined, it is in pixel and updated accordingly
   # Get conversion factor between pixels and inches, dev.size provides an array c(width, height)


### PR DESCRIPTION
- restore DDI axis labels that were no longer appearing
- restore DDI legend position to `outsideRight`

[currentReport.zip](https://github.com/Open-Systems-Pharmacology/OSPSuite.ReportingEngine/files/7783755/currentReport.zip)
 