### PR TITLE
Fixes #665 typo in template

### DIFF
--- a/R/error-checks.R
+++ b/R/error-checks.R
@@ -119,7 +119,7 @@ validateIsFileExtension <- function(path, extension, nullAllowed = FALSE) {
   if (isFileExtension(path, extension)) {
     return(invisible())
   }
-  logErrorThenStop(messages$errorExtension(path, extension))
+  stop(messages$errorExtension(path, extension))
 }
 
 #' Log the error with a message and then stop, displaying same message.

--- a/R/error-checks.R
+++ b/R/error-checks.R
@@ -122,6 +122,16 @@ validateIsFileExtension <- function(path, extension, nullAllowed = FALSE) {
   stop(messages$errorExtension(path, extension))
 }
 
+validateFileExists <- function(path, nullAllowed = FALSE) {
+  if (nullAllowed && is.null(path)) {
+    return(invisible())
+  }
+  if (file.exists(path)){
+    return(invisible())
+  }
+  stop(messages$errorUnexistingFile(path))
+}
+
 #' Log the error with a message and then stop, displaying same message.
 #'
 #' @param message message to display and then log

--- a/R/messages.R
+++ b/R/messages.R
@@ -53,6 +53,10 @@ messages <- list(
   warningExistingPath = function(existingPath) {
     paste0(callingFunction(), "Path: '", existingPath, "' already exists.")
   },
+  
+  errorUnexistingFile = function(path) {
+    paste0(callingFunction(), "File: '", path, "' does not exist.")
+  },
 
   warningPathIncludes = function(path) {
     paste0(

--- a/R/utilities-qualification.R
+++ b/R/utilities-qualification.R
@@ -5,6 +5,7 @@
 #' @return A `QualificationWorkflow` object
 #' @export
 loadQualificationWorkflow <- function(workflowFolder, configurationPlanFile) {
+  validateIsFileExtension(configurationPlanFile, "json")
   configurationPlan <- loadConfigurationPlan(
     workflowFolder = workflowFolder,
     configurationPlanFile = configurationPlanFile

--- a/R/utilities-qualification.R
+++ b/R/utilities-qualification.R
@@ -6,6 +6,7 @@
 #' @export
 loadQualificationWorkflow <- function(workflowFolder, configurationPlanFile) {
   validateIsFileExtension(configurationPlanFile, "json")
+  validateFileExists(configurationPlanFile)
   configurationPlan <- loadConfigurationPlan(
     workflowFolder = workflowFolder,
     configurationPlanFile = configurationPlanFile

--- a/inst/extdata/qualification-workflow-template.R
+++ b/inst/extdata/qualification-workflow-template.R
@@ -47,7 +47,7 @@ reOutputFolder <- file.path(workingDirectory, "re_output")
 
 #' Configuration Plan created from the Qualification Plan by the Qualification Runner
 configurationPlanName <- "report-configuration-plan"
-configurationPlanFile <- file.path(reInputFolder, paste0(configurationPlanName, "json"))
+configurationPlanFile <- file.path(reInputFolder, paste0(configurationPlanName, ".json"))
 
 #' Option to record the time require to run the workflow.
 #' The timer will calculate calculation time form internal `Sys.time` function


### PR DESCRIPTION
The error message from `jsonlite` was not helpful because the function accepts both a path of json file and its content.
I have included a `validateIsFileExtension` from reporting engine as the method is not yet in `{ospsuite.utils}`