### PR TITLE
Fixes #672 prevent crash of gof plot when Inf values are introduced

### DIFF
--- a/R/qualification-gof.R
+++ b/R/qualification-gof.R
@@ -226,15 +226,15 @@ getQualificationGOFPlot <- function(plotType, data, metaData, axesProperties) {
     autoAxesLimits(switch(
       plotType,
       "predictedVsObserved" = dataForLimit,
-      "residualsOverTime" = data[, "Time"]
+      "residualsOverTime" = data[positiveRows, "Time"]
     ))
   plotConfiguration$yAxis$limits <- c(axesProperties$x$min, axesProperties$x$max) %||%
     autoAxesLimits(switch(
       plotType,
       "predictedVsObserved" = dataForLimit,
-      "residualsOverTime" = c(0, data[, "Residuals"])
+      "residualsOverTime" = c(0, data[positiveRows, "Residuals"])
     ))
-
+  
   gofPlot <- switch(
     plotType,
     "predictedVsObserved" = tlf::plotObsVsPred(


### PR DESCRIPTION
The crash actually came from the auto scaling of the axes.
Since the data included Inf, ggplot was trying to scale to Inf and crashed (the Inf data point only leads to warnings from ggplot).
For tlf, this means there needs to be 2 layers in handling Inf and NAs: one regarding the data points to plot and one preventing scaling by Inf values