### PR TITLE
Fixes #709 update test better checking what is expected

### DIFF
--- a/R/population-study-design.R
+++ b/R/population-study-design.R
@@ -21,6 +21,8 @@ addStudyParameters <- function(population, simulation, studyDesignFile) {
 
     population$setParameterValues(parameterPath, updatedTargetValues)
   }
+  # Since population is updated R6 object, no need to export it
+  return(invisible())
 }
 
 #' @title loadStudyDesign

--- a/tests/testthat/test-study-design.R
+++ b/tests/testthat/test-study-design.R
@@ -63,11 +63,11 @@ test_that("Units and paths are checked and converted to base unit when loading a
     check.names = FALSE
   )
   write.csv(studyDesignData, file = studyDesignTempFile, row.names = FALSE)
-  expect_silent(loadStudyDesign(studyDesignTempFile, testPopulation, testSimulation))
-  expect_silent(addStudyParameters(testPopulation, testSimulation, studyDesignTempFile))
   studyDesign <- loadStudyDesign(studyDesignTempFile, testPopulation, testSimulation)
+  expect_s3_class(studyDesign, "StudyDesign")
   expect_equal(studyDesign$targets[[1]]$name, "Organism|Height")
   expect_equal(studyDesign$targets[[1]]$values, 17)
+  expect_null(addStudyParameters(testPopulation, testSimulation, studyDesignTempFile))
   unlink(studyDesignTempFile, recursive = TRUE)
 
   # Example on source Weight in wrong unit
@@ -101,8 +101,8 @@ test_that("Units and paths are checked and converted to base unit when loading a
     check.names = FALSE
   )
   write.csv(studyDesignData, file = studyDesignTempFile, row.names = FALSE)
-  expect_silent(loadStudyDesign(studyDesignTempFile, testPopulation, testSimulation))
-  expect_silent(addStudyParameters(testPopulation, testSimulation, studyDesignTempFile))
+  expect_s3_class(loadStudyDesign(studyDesignTempFile, testPopulation, testSimulation), "StudyDesign")
+  expect_null(addStudyParameters(testPopulation, testSimulation, studyDesignTempFile))
   addStudyParameters(testPopulation, testSimulation, studyDesignTempFile)
   populationData <- ospsuite::populationAsDataFrame(testPopulation)
   # Base unit gives 17 dm for target
@@ -133,14 +133,14 @@ test_that("A study design 'SOURCE' requires a 'MIN', 'MAX', or 'EQUALS' attribut
   testPopulation <- ospsuite::loadPopulation(populationFile)
   testSimulation <- ospsuite::loadSimulation(simulationFile)
 
-  expect_silent(loadStudyDesign(studyDesignMinFile, testPopulation, testSimulation))
-  expect_silent(loadStudyDesign(studyDesignMaxFile, testPopulation, testSimulation))
-  expect_silent(loadStudyDesign(studyDesignEqualsFile, testPopulation, testSimulation))
+  expect_s3_class(loadStudyDesign(studyDesignMinFile, testPopulation, testSimulation), "StudyDesign")
+  expect_s3_class(loadStudyDesign(studyDesignMaxFile, testPopulation, testSimulation), "StudyDesign")
+  expect_s3_class(loadStudyDesign(studyDesignEqualsFile, testPopulation, testSimulation), "StudyDesign")
   expect_error(loadStudyDesign(studyDesignElseFile, testPopulation, testSimulation))
 
-  expect_silent(addStudyParameters(testPopulation, testSimulation, studyDesignMinFile))
-  expect_silent(addStudyParameters(testPopulation, testSimulation, studyDesignMaxFile))
-  expect_silent(addStudyParameters(testPopulation, testSimulation, studyDesignEqualsFile))
+  expect_null(addStudyParameters(testPopulation, testSimulation, studyDesignMinFile))
+  expect_null(addStudyParameters(testPopulation, testSimulation, studyDesignMaxFile))
+  expect_null(addStudyParameters(testPopulation, testSimulation, studyDesignEqualsFile))
   expect_error(addStudyParameters(testPopulation, testSimulation, studyDesignElseFile))
 })
 
@@ -254,3 +254,8 @@ test_that("Source expressions constraints add up as &", {
   unlink(studyDesignFile, recursive = TRUE)
   unlink(studyDesignNAFile, recursive = TRUE)
 })
+
+# Clear logs
+unlink("log-error.txt", recursive = TRUE)
+unlink("log-debug.txt", recursive = TRUE)
+unlink("log-info.txt", recursive = TRUE)


### PR DESCRIPTION
Initially, expect_silent was used to check that no error was thrown.
Since the last opsuite update some function are depcecated and throw warnings