### PR TITLE
FIxes #728 simulation errors are not catched

### DIFF
--- a/R/utilities-simulation.R
+++ b/R/utilities-simulation.R
@@ -181,6 +181,8 @@ simulateModelParallel <- function(structureSets,
       logTypes = LogTypes$Info
     )
     
+    # Catch, save and display any error or warning
+    # from ospsuite::runSimulations
     subsetSimulationResults <- tryCatch({
        ospsuite::runSimulations(simulations = simulations)
     },
@@ -193,10 +195,12 @@ simulateModelParallel <- function(structureSets,
         pathFolder = logFolder,
         logTypes = LogTypes$Error
       )
-      return(ospsuite::runSimulations(simulations = simulations))
+      # Since simulationResults is a list,
+      # return same output type
+      return(vector(mode = "list", length = length(simulations)))
     })
     
-    simulationResults <- c(simulationResults,subsetSimulationResults)
+    simulationResults <- c(simulationResults, subsetSimulationResults)
 
   }
 

--- a/R/utilities-simulation.R
+++ b/R/utilities-simulation.R
@@ -180,11 +180,22 @@ simulateModelParallel <- function(structureSets,
       pathFolder = logFolder,
       logTypes = LogTypes$Info
     )
-
-    subsetSimulationResults <- ospsuite::runSimulations(
-      simulations = simulations
-    )
-
+    
+    subsetSimulationResults <- tryCatch({
+       ospsuite::runSimulations(simulations = simulations)
+    },
+    error = function(e) {
+      logErrorThenStop(message = e, logFolder)
+      },
+    warning = function(w) {
+      logWorkflow(
+        message = w,
+        pathFolder = logFolder,
+        logTypes = LogTypes$Error
+      )
+      return(ospsuite::runSimulations(simulations = simulations))
+    })
+    
     simulationResults <- c(simulationResults,subsetSimulationResults)
 
   }


### PR DESCRIPTION
In case of simple warning, the simulations that worked are currently re-run and output. Let me know if this needs to be changed