### PR TITLE
Fixes #909 use limits and ticks from boxplots for range plots

### DIFF
--- a/R/utilities-calculate-pk-parameters.R
+++ b/R/utilities-calculate-pk-parameters.R
@@ -340,7 +340,12 @@ plotPopulationPKParameters <- function(structureSets,
             resultID <- defaultFileNames$resultID(length(pkParametersResults) + 1, "pk_parameters", demographyParameter, pkParameter$pkParameter, "log")
             pkParametersResults[[resultID]] <- saveTaskResults(
               id = resultID,
-              plot = tlf::setYAxis(plotObject = comparisonVpcPlot, scale = tlf::Scaling$log),
+              plot = tlf::setYAxis(
+                plotObject = comparisonVpcPlot, 
+                scale = tlf::Scaling$log,
+                limits = boxRange,
+                ticks = boxBreaks
+                ),
               plotCaption = captions$plotPKParameters$rangePlot(
                 xParameterCaption,
                 yParameterCaption,
@@ -388,7 +393,12 @@ plotPopulationPKParameters <- function(structureSets,
           resultID <- defaultFileNames$resultID(length(pkParametersResults) + 1, "pk_parameters", demographyParameter, pkParameter$pkParameter, "log")
           pkParametersResults[[resultID]] <- saveTaskResults(
             id = resultID,
-            plot = tlf::setYAxis(plotObject = vpcPlot, scale = tlf::Scaling$log),
+            plot = tlf::setYAxis(
+              plotObject = vpcPlot, 
+              scale = tlf::Scaling$log,
+              limits = boxRange,
+              ticks = boxBreaks
+              ),
             plotCaption = captions$plotPKParameters$rangePlot(
               xParameterCaption,
               yParameterCaption,


### PR DESCRIPTION
`{ggplot2}` crashes when logticks can't be added on log plots (`Error in unit(yticks$start, "cm")`)
The issue was encountered a while ago for boxplots and was fixed by calculating sensible ticks and limits then. Since range plots use the same data, the boxplot ticks and limits can be re-used.