### PR TITLE
Fixes #811 remove blue line from legend shaded area

### DIFF
--- a/inst/extdata/re-theme.json
+++ b/inst/extdata/re-theme.json
@@ -198,10 +198,10 @@
       "alpha": 1
     },
     "addRibbon": {
-      "color": "#0078D7",
+      "color": "black",
       "fill": "#0078D7",
       "shape": "blank",
-      "linetype": "solid",
+      "linetype": "blank",
       "size": 1,
       "alpha": 0.2
     },


### PR DESCRIPTION
For some reason, the properties defined in color and linetype of ribbons are actually used to create the legend key even if they are not used by the ribbon itself. Using a blank linetype remove the line from the legend key.