### PR TITLE
Fixes #497 use option stopIfNotFound=FALSE to prevent sensitivity crash

### DIFF
--- a/R/utilities-simulation.R
+++ b/R/utilities-simulation.R
@@ -342,7 +342,13 @@ updateSimulationIndividualParameters <- function(simulation, individualParameter
   if (is.null(individualParameters)) {
     return(TRUE)
   }
-  ospsuite::setParameterValuesByPath(parameterPaths = individualParameters$paths, values = individualParameters$values, simulation = simulation)
+  ospsuite::setParameterValuesByPath(
+    parameterPaths = individualParameters$paths, 
+    values = individualParameters$values, 
+    simulation = simulation,
+    # Issue #497 prevent crash if parameter is not found
+    stopIfNotFound = FALSE
+    )
   return(TRUE)
 }
 


### PR DESCRIPTION
There is currently no warning when this option is set to `FALSE` (I have submitted issue [#1240](https://github.com/Open-Systems-Pharmacology/OSPSuite-R/issues/1240) for handling that).
Once the function throws a warning, the workflow will automatically catch it and display the message as a warning in console and logs.
