### PR TITLE
Fixes #1055 update word reports

### DIFF
--- a/R/utilities-writing-report.R
+++ b/R/utilities-writing-report.R
@@ -756,7 +756,7 @@ copyReport <- function(from, to, copyWordReport = TRUE, keep = FALSE) {
   dir.create(toFolder, showWarnings = FALSE, recursive = TRUE)
   file.copy(from, to, overwrite = TRUE)
   if (copyWordReport) {
-    file.copy(from = fromWordReport, to = toWordReport)
+    file.copy(from = fromWordReport, to = toWordReport, overwrite = TRUE)
   }
 
   # Copy the figures in destination folder to have them available for new report


### PR DESCRIPTION
Actually, this was not a pandoc issue but a missing `overwrite` parameter in `copyReport()`