### PR TITLE
Fixes #1071 auto-numbering does not mess up static images

### DIFF
--- a/R/utilities-writing-report.R
+++ b/R/utilities-writing-report.R
@@ -701,9 +701,8 @@ updateArtifactNumbers <- function(fileContent, pattern, replacement, anchorId, c
       updatedFileContent <- c(updatedFileContent, fileContent[lineIndex])
       next
     }
-    # Else line starts by Figure or Table
+    # Else line starts by "Figure:" or "Table:"
     # Update caption with appropriate figure/table count
-    # TODO: should we prevent auto-numbering when users included their own numbering ?
     updatedArtifactContent <- gsub(
       pattern = pattern,
       replacement = paste0(replacement, " ", artifactNumber, ":"),

--- a/tests/data/utilities-report/testReportNumFigs.md
+++ b/tests/data/utilities-report/testReportNumFigs.md
@@ -7,15 +7,9 @@
 ## Sub title 1
 
 
-<a id="figure-1-1"></a>
-
-
 Figure 1-1: this is figure 1
 
 ## Sub title 2
-
-
-<a id="figure-1-2"></a>
 
 
 Figure 1-2: this is figure 2
@@ -28,16 +22,11 @@ Figure 1-2: this is figure 2
 
 ## Sub title 1
 
-
 <a id="table-2-1"></a>
-
 
 Table 2-1: this is table 1
 
 ## Sub title 2
-
-
-<a id="figure-2-1"></a>
 
 
 Figure 2-1: this is figure 3

--- a/tests/data/utilities-report/testReportNumSecs.md
+++ b/tests/data/utilities-report/testReportNumSecs.md
@@ -7,15 +7,9 @@
 ## Sub title 1
 
 
-<a id="figure-1-1"></a>
-
-
 Figure 1-1: this is figure 1
 
-## 1.1 Sub title 2
-
-
-<a id="figure-1-2"></a>
+## Sub title 2
 
 
 Figure 1-2: this is figure 2
@@ -28,16 +22,11 @@ Figure 1-2: this is figure 2
 
 ## 2.1 Sub title 1
 
-
 <a id="table-2-1"></a>
-
 
 Table 2-1: this is table 1
 
 ## 2.2 Sub title 2
-
-
-<a id="figure-2-1"></a>
 
 
 Figure 2-1: this is figure 3

--- a/tests/data/utilities-report/testReportNumToc.md
+++ b/tests/data/utilities-report/testReportNumToc.md
@@ -1,7 +1,6 @@
 # Table of Contents
 
  * [1 Title 1](#title-1)
-   * [1.1 Sub title 2](#figure-1-1)
  * [2 Title 2](#title-2)
    * [2.1 Sub title 1](#subtitle-21)
    * [2.2 Sub title 2](#table-2-1)
@@ -16,15 +15,9 @@
 ## Sub title 1
 
 
-<a id="figure-1-1"></a>
-
-
 Figure 1-1: this is figure 1
 
-## 1.1 Sub title 2
-
-
-<a id="figure-1-2"></a>
+## Sub title 2
 
 
 Figure 1-2: this is figure 2
@@ -37,16 +30,11 @@ Figure 1-2: this is figure 2
 
 ## 2.1 Sub title 1
 
-
 <a id="table-2-1"></a>
-
 
 Table 2-1: this is table 1
 
 ## 2.2 Sub title 2
-
-
-<a id="figure-2-1"></a>
 
 
 Figure 2-1: this is figure 3


### PR DESCRIPTION
The auto-numbering algorithm for Figures assumes that the caption is below the figure. In the qualification example, it was above. The fix renders a more robust way of including the bookmarks before the figure without needing a placeholder for the md figure inclusion line