### PR TITLE
Fixes #1082 no observed data does not crash qualification time profile

### DIFF
--- a/R/qualification-time-profile.R
+++ b/R/qualification-time-profile.R
@@ -783,14 +783,14 @@ updateQualificationTimeProfilePlotConfiguration <- function(simulatedMetaData = 
                                                             axesProperties = NULL,
                                                             plotConfiguration) {
   # Update plot configuration for simulated values
-  if (!isEmpty(simulatedMetaData)) {
+  if (!isEmpty(simulatedMetaData$id)) {
     sortedSimulatedMetaData <- order(simulatedMetaData$id)
     plotConfiguration$lines$color <- simulatedMetaData$color[sortedSimulatedMetaData]
     plotConfiguration$lines$linetype <- simulatedMetaData$linetype[sortedSimulatedMetaData]
     plotConfiguration$lines$size <- simulatedMetaData$size[sortedSimulatedMetaData]
   }
   # Update plot configuration for observed values
-  if (!isEmpty(observedMetaData)) {
+  if (!isEmpty(observedMetaData$id)) {
     sortedObservedMetaData <- order(observedMetaData$id)
     # offset of simulated data colors
     plotConfiguration$points$color <- c(


### PR DESCRIPTION
@Yuri05 
I was not expecting the following behavior from the function `isEmpty` (from the package `{ospsuite.utils}`):
A named list with only `NULL` elements is not considered empty while a data.frame with only `NULL` columns is empty.

```r
> isEmpty(list(a=NULL))
[1] FALSE

> length(list(a=NULL))
[1] 1

> isEmpty(data.frame(a=NULL))
[1] TRUE

> length(data.frame(a=NULL))
[1] 0
```

Let me know if this requires also an update on the `{ospsuite.utils}` side ?