### PR TITLE
Fixes #1085 Update ratio message to indicate PK parameter

### DIFF
--- a/R/messages.R
+++ b/R/messages.R
@@ -259,6 +259,21 @@ messages <- list(
   subsetsCreated = function(numberOfSubsets, numberOfSimulations) {
     paste0("Splitting simulations for parallel run:", highlight(numberOfSimulations), " simulations split into ", highlight(numberOfSubsets), " subsets")
   },
+  ratioIdentifiedPopulations = function(outputName, 
+                                        pkParameterName, 
+                                        simulationSetName, 
+                                        referenceSimulationSetName, 
+                                        isSamePopulation = TRUE){
+    paste0(
+      "Simulation Set '", highlight(simulationSetName),
+      "' was identified with population ", 
+      highlight(ifelse(isSamePopulation, "same", "different")),
+      " from reference '", highlight(referenceSimulationSetName), "'.\n",
+      "Ratio comparison of ", highlight(pkParameterName), " of ", highlight(outputName),
+      " uses ", highlight(ifelse(isSamePopulation, "Individual PK Ratios", "Monte Carlo Sampling")),
+      " for analyzing statistics."
+    )
+  },
 
   #----- Debug messages ----
   dataIncludedInTimeRange = function(finalSize, timeRange, timeUnit, dataType) {

--- a/R/utilities-ratio-comparison.R
+++ b/R/utilities-ratio-comparison.R
@@ -111,14 +111,15 @@ getPKParameterRatioPKTable <- function(data,
   referenceData <- data[data$simulationSetName %in% referenceSimulationSetName, ]
   ratioPKTable <- data.frame()
   for (set in populationSets) {
+    logInfo(messages$ratioIdentifiedPopulations(
+      outputName = head(data$QuantityPath, 1),
+      pkParameterName = head(data$Parameter, 1), 
+      simulationSetName = set$simulationSetName, 
+      referenceSimulationSetName = referenceSimulationSetName,
+      isSamePopulation = set$isSamePopulation
+    ))
     comparisonData <- data[data$simulationSetName %in% set$simulationSetName, ]
     if (set$isSamePopulation) {
-      logInfo(paste0(
-        "Simulation Set '", set$simulationSetName,
-        "' was identified with same population as reference '",
-        referenceSimulationSetName, "'. ",
-        "Ratio comparison analyzed statistics of individual PK ratios."
-      ))
       ratioData <- comparisonData
       # TODO: tlf issue #408
       # simulationSetName is factor class including multiple levels
@@ -130,12 +131,6 @@ getPKParameterRatioPKTable <- function(data,
       ratioPKTable <- rbind.data.frame(ratioPKTable, ratioPKMeasure)
       next
     }
-    logInfo(paste0(
-      "Simulation Set '", set$simulationSetName,
-      "' was identified with population different from reference '",
-      referenceSimulationSetName, "'. ",
-      "Ratio comparison analyzed statistics from Monte Carlo Sampling"
-    ))
     # Get simulation structure set to save mc results
     ratioPKMeasure <- getPKParameterRatioMeasureFromMCSampling(
       comparisonData = comparisonData,


### PR DESCRIPTION
With this PR the new messages are

## Same population

$\text{\color{green}{i Info} \color{black}{Simulation Set '}\color{blue}{simulation set name}\color{black}{' was identified with population} \color{blue}{same} \color{black}{from reference '}\color{blue}{Reference simulation set name}'.}$
$\text{\color{black}{Ratio comparison of} \color{blue}{PK Parameter} \color{black}{of} \color{blue}{Output path} \color{black}{uses} \color{blue}{Individual PK Ratios} \color{black}{for analyzing statistics.}}$

## Different population

$\text{\color{green}{i Info} \color{black}{Simulation Set '}\color{blue}{simulation set name}\color{black}{' was identified with population} \color{blue}{different} \color{black}{from reference '}\color{blue}{Reference simulation set name}'.}$
$\text{\color{black}{Ratio comparison of} \color{blue}{PK Parameter} \color{black}{of} \color{blue}{Output path} \color{black}{uses} \color{blue}{Monte Carlo Sampling} \color{black}{for analyzing statistics.}}$
$\text{\color{green}{i Info}  \color{black}{Analysis of PK Ratios between 'simulation set name'}} (n=n_X) \text{ against reference 'simulation set name'} (n=n_Y)$
$\text{Analytical solution for mean, standard deviation, geo mean, geo standard deviation resulted in ... respectively}$
$\text{Monte Carlo solution for mean, standard deviation, geo mean, geo standard deviation resulted in ... respectively.}$
$\text{Number of repetitions was set to: ...}$
$\text{Random seed number was set to: ...}$
