### PR TITLE
Fixes #1016

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The **OSPSuite.ReportingEngine** package is compatible with version 3.6.x **AND*
 
 [OPTIONAL] Install **rsvg-convert** (required by Pandoc for conversion of images in SVG format)
 
-* [Installer (Windows)]([Releases · miyako/console-rsvg-convert (github.com)](https://github.com/miyako/console-rsvg-convert/releases))
+* [Installer (Windows)](https://github.com/miyako/console-rsvg-convert/releases)
   * The installation folder must be added to the system path.
 * For Linux, **librsvg** package must be installed (package name depends on distribution, e.g. **librsvg2-bin** for Ubuntu).
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The **OSPSuite.ReportingEngine** package is compatible with version 3.6.x **AND*
 * [Pandoc Installer (Windows)](https://github.com/jgm/pandoc/releases/download/2.9.2.1/pandoc-2.9.2.1-windows-x86_64.msi)
 * [Pandoc Installer (Linux)](https://github.com/jgm/pandoc/releases/download/2.9.2.1/pandoc-2.9.2.1-linux-amd64.tar.gz)
 
-[OPTIONAL] Install **rsvg-convert** (required by pandoc for conversion of images in SVG format)
+[OPTIONAL] Install **rsvg-convert** (required by Pandoc for conversion of images in SVG format)
 
 * [Installer (Windows)]([Releases · miyako/console-rsvg-convert (github.com)](https://github.com/miyako/console-rsvg-convert/releases))
   * The installation folder must be added to the system path.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ The **OSPSuite.ReportingEngine** package is compatible with version 3.6.x **AND*
 * [Pandoc Installer (Windows)](https://github.com/jgm/pandoc/releases/download/2.9.2.1/pandoc-2.9.2.1-windows-x86_64.msi)
 * [Pandoc Installer (Linux)](https://github.com/jgm/pandoc/releases/download/2.9.2.1/pandoc-2.9.2.1-linux-amd64.tar.gz)
 
+[OPTIONAL] Install **rsvg-convert** (required by pandoc for conversion of images in SVG format)
+
+* [Installer (Windows)]([Releases · miyako/console-rsvg-convert (github.com)](https://github.com/miyako/console-rsvg-convert/releases))
+  * The installation folder must be added to the system path.
+* For Linux, **librsvg** package must be installed (package name depends on distribution, e.g. **librsvg2-bin** for Ubuntu).
+
 # Development tasks
 
 ## dev_mode


### PR DESCRIPTION
No functional changes, just an update of installation instructions.

It turned out that for correct conversion of reports with SVG images from .MD to .docx via Pandoc one extra command line utility is required: **rsvg-convert**.
Under Linux it's part of librsvg package, under Windows it can be installed as a standalone command line tool.