### PR TITLE
Fixes #1168 prevent logging of new messages in old workflow folders

### DIFF
--- a/R/mean-model-workflow.R
+++ b/R/mean-model-workflow.R
@@ -126,6 +126,9 @@ MeanModelWorkflow <- R6::R6Class(
         re.tEndMetadataCapture(outputFolder = "./", actionToken = actionToken1)
       })
       logInfo(messages$runCompleted(getElapsedTime(t0), "Mean Model Workflow"))
+      # Stop logging messages in workflowFolder after run is completed 
+      # Prevents potential logging of new messages in previous workflowFolder
+      setLogFolder()
     }
   )
 )

--- a/R/population-workflow.R
+++ b/R/population-workflow.R
@@ -161,6 +161,9 @@ PopulationWorkflow <- R6::R6Class(
         re.tEndMetadataCapture(outputFolder = "./", actionToken = actionToken1)
       })
       logInfo(messages$runCompleted(getElapsedTime(t0), "Population Workflow", self$workflowType))
+      # Stop logging messages in workflowFolder after run is completed 
+      # Prevents potential logging of new messages in previous workflowFolder
+      setLogFolder()
     }
   )
 )

--- a/R/qualification-workflow.R
+++ b/R/qualification-workflow.R
@@ -108,6 +108,9 @@ QualificationWorkflow <- R6::R6Class(
         copyReport(from = initialReportPath, to = self$reportFilePath, copyWordReport = self$createWordReport, keep = TRUE)
       })
       logInfo(messages$runCompleted(getElapsedTime(t0), "Qualification Workflow"))
+      # Stop logging messages in workflowFolder after run is completed 
+      # Prevents potential logging of new messages in previous workflowFolder
+      setLogFolder()
     },
 
     #' @description

--- a/R/utilities-logging.R
+++ b/R/utilities-logging.R
@@ -176,6 +176,7 @@ logCatch <- function(expr) {
           "rows containing non-finite values",
           "Ignoring unknown parameters",
           "was deprecated in ggplot2",
+          "font family not found in Windows font database",
           # warning thrown because of non-ASCII unicode characters
           "mbcsToSbcs"
         ),

--- a/R/utilities-logging.R
+++ b/R/utilities-logging.R
@@ -39,7 +39,7 @@ getTimeStamp <- function() {
 #' @description Reset/empty messages of global logging system
 #' @param folder Folder where logs are saved
 #' @keywords internal
-resetLogs <- function(folder) {
+resetLogs <- function(folder = NULL) {
   reEnv$log$reset(folder)
   return(invisible())
 }
@@ -48,7 +48,7 @@ resetLogs <- function(folder) {
 #' @description Set folder where logs are saved
 #' @param folder Folder where logs are saved
 #' @keywords internal
-setLogFolder <- function(folder) {
+setLogFolder <- function(folder = NULL) {
   reEnv$log$folder <- folder
   return(invisible())
 }
@@ -101,6 +101,7 @@ logError <- function(message, printConsole = NULL) {
 #' @keywords internal
 logErrorThenStop <- function(message, logFolder = NULL) {
   logError(message, printConsole = FALSE)
+  setLogFolder()
   stop(as.character(message), call. = FALSE)
 }
 
@@ -201,6 +202,8 @@ logCatch <- function(expr) {
     }
   ),
   error = function(errorCondition) {
+    # Prevent logging new messages in old log files after crash
+    setLogFolder()
     stop(errorCondition$message, call. = FALSE)
   }
   )

--- a/man/resetLogs.Rd
+++ b/man/resetLogs.Rd
@@ -4,7 +4,7 @@
 \alias{resetLogs}
 \title{resetLogs}
 \usage{
-resetLogs(folder)
+resetLogs(folder = NULL)
 }
 \arguments{
 \item{folder}{Folder where logs are saved}

--- a/man/setLogFolder.Rd
+++ b/man/setLogFolder.Rd
@@ -4,7 +4,7 @@
 \alias{setLogFolder}
 \title{setLogFolder}
 \usage{
-setLogFolder(folder)
+setLogFolder(folder = NULL)
 }
 \arguments{
 \item{folder}{Folder where logs are saved}

--- a/tests/testthat/test-configuration-plan.R
+++ b/tests/testthat/test-configuration-plan.R
@@ -93,8 +93,6 @@ test_that("Duplicated Ids for ObservedDataSets is correctly handled", {
   ))
 })
 
-unlink(workflowFolder, recursive = TRUE)
-
 # Function is not exported
 getPlotConfigurationFromPlan <- ospsuite.reportingengine:::getPlotConfigurationFromPlan
 
@@ -106,3 +104,5 @@ test_that("PlotConfiguration default for observed vs predicted is quadratic", {
     defaultObsVsPredConfiguration$export$height
   )
 })
+
+unlink(workflowFolder, recursive = TRUE)

--- a/tests/testthat/test-ddi-report.R
+++ b/tests/testthat/test-ddi-report.R
@@ -79,3 +79,4 @@ test_that("Subunits are included in TOC", {
 
 # Clear the output
 removeAllUserDefinedPKParameters()
+unlink(reOutputFolder, recursive = TRUE)

--- a/tests/testthat/test-logging.R
+++ b/tests/testthat/test-logging.R
@@ -1,0 +1,51 @@
+test_that("Timer works as expected", {
+  t0 <- ospsuite.reportingengine:::tic()
+  Sys.sleep(4)
+  t1 <- ospsuite.reportingengine:::getElapsedTime(t0)
+  expect_equal(t1, "0.1 min")
+})
+
+unlink("test-logs", recursive = TRUE)
+test_that("resetLogs reset log messages and set the log folder", {
+  resetLogs("test-logs")
+  expect_equal(
+    ospsuite.reportingengine:::reEnv$log$folder, 
+    "test-logs"
+    )
+  # Because messages is empty list, cannot use expect_null
+  expect_length(
+    ospsuite.reportingengine:::reEnv$log$messages, 
+    0
+  )
+})
+
+test_that("log functions record to the appropriate files", {
+  logInfo("info message")
+  expect_true(file.exists("test-logs/log-info.txt"))
+  logError("error message")
+  expect_true(file.exists("test-logs/log-error.txt"))
+  logDebug("debug message")
+  expect_true(file.exists("test-logs/log-debug.txt"))
+})
+
+
+test_that("Every warning and error message in logCatch is logged", {
+  # Actually catch, display warning as message, keep recording in same logs
+  unlink("test-logs/log-error.txt", recursive = TRUE)
+  logCatch({warning("warning message")})
+  expect_true(file.exists("test-logs/log-error.txt"))
+  expect_equal(
+    ospsuite.reportingengine:::reEnv$log$folder, 
+    "test-logs"
+  )
+  
+  # Actually catch, display error as error and reset to prevent new messages in old logs
+  unlink("test-logs/log-error.txt", recursive = TRUE)
+  expect_error(logCatch({stop("error message")})) 
+  expect_true(file.exists("test-logs/log-error.txt"))
+  expect_null(ospsuite.reportingengine:::reEnv$log$folder)
+})
+
+resetLogs()
+unlink("test-logs", recursive = TRUE)
+

--- a/tests/testthat/test-workflow-structure.R
+++ b/tests/testthat/test-workflow-structure.R
@@ -59,5 +59,6 @@ test_that("Workflows initialization creates appropriate folder and logs, and war
   expect_false("log-debug.txt" %in% list.files(testFolder))
   expect_false("log-error.txt" %in% list.files(testFolder))
 
+  resetLogs()
   unlink(testFolder, recursive = TRUE)
 })


### PR DESCRIPTION
I was not able to reproduce issue #1168.
I identified 2 potential reasons for the 5 failed tests:

1- new messages are logged in the old workflow folders (this PR aims at preventing that)
2- unexpected warning messages are thrown and logged in the local tests (such as functions deprecated, etc.)

If possible, couId you send the log-error.txt so that I can identify the message.
Best case, I can include the message into the list of message that `logCatch` needs to mute and log in the debug files: https://github.com/Open-Systems-Pharmacology/OSPSuite.ReportingEngine/blob/37541521906fdd6b22347837179f6b58291faef5/R/utilities-logging.R#L169-L180