### PR TITLE
Fixes #67 Remove TODOs and create actual issues

### DIFF
--- a/R/configuration-plan.R
+++ b/R/configuration-plan.R
@@ -250,7 +250,6 @@ ConfigurationPlan <- R6::R6Class(
       reEnv$theme$fonts$legend$size <- self$plots$PlotSettings$Fonts$LegendSize %||% reEnv$theme$fonts$legend$size
       reEnv$theme$fonts$xAxis$size <- self$plots$PlotSettings$Fonts$AxisSize %||% reEnv$theme$fonts$xAxis$size
       reEnv$theme$fonts$yAxis$size <- self$plots$PlotSettings$Fonts$AxisSize %||% reEnv$theme$fonts$yAxis$size
-      # TODO resizing of the input: normal size always appears bigger in background due to annotation_custom()
       reEnv$theme$fonts$watermark$size <- self$plots$PlotSettings$Fonts$WatermarkSize %||% reEnv$theme$fonts$watermark$size
       return(invisible())
     }

--- a/R/error-checks.R
+++ b/R/error-checks.R
@@ -46,7 +46,6 @@ validateNoDuplicatedEntries <- function(x) {
   return(invisible())
 }
 
-# TODO: replace the function name
 validateIsIncludedAndLog <- function(values, parentValues, nullAllowed = FALSE, groupName = NULL) {
   if (nullAllowed && is.null(values)) {
     return(invisible())

--- a/R/gof-plot-task.R
+++ b/R/gof-plot-task.R
@@ -238,8 +238,8 @@ GofPlotTask <- R6::R6Class(
         includeTable = FALSE
       )
 
-      # Get all unique output paths
-      # TODO: group them by unique ID once introduced
+      # Get all unique output paths and 
+      # issue #1188: need to group them by unique groupID
       allOutputs <- sapply(
         structureSets,
         FUN = function(set) {

--- a/R/qualification-gof.R
+++ b/R/qualification-gof.R
@@ -149,7 +149,6 @@ getGOFDataForMapping <- function(outputMapping, configurationPlan, axesUnits) {
     )
 
     # Re-use nomenclature and functions from utilities-goodness-of-fit
-    # TODO: Qualification currently do not handle LLOQ
     # Add place holder for lloq, that will be replaced once data include lloq information
     observedData <- data.frame(
       Time = observedTime,

--- a/R/qualification-pk-ratio.R
+++ b/R/qualification-pk-ratio.R
@@ -94,7 +94,6 @@ getQualificationPKRatioGMFE <- function(pkParameterNames, data) {
 #' @return A data.frame
 #' @keywords internal
 getQualificationPKRatioMeasure <- function(pkParameterName, data, metaData) {
-  # TODO: use tlf::getPKRatioMeasure once updated on tlf
   ratios <- data[, paste0("ratio", pkParameterName)]
   ratios <- ratios[!is.na(ratios)]
 

--- a/R/qualification-time-profile.R
+++ b/R/qualification-time-profile.R
@@ -572,7 +572,6 @@ getTimeProfileObservedDataFromResults <- function(observedResults, molWeight, ax
     }
   )
   if (isEmpty(outputValues)) {
-    # TODO: change error message
     stop(messages$errorMolecularWeightRequired(""))
   }
 

--- a/R/reportingengine-env.R
+++ b/R/reportingengine-env.R
@@ -142,7 +142,11 @@ getDefaultRETheme <- function() {
     return(tlf::loadThemeFromJson(reThemeFile))
   }
   # If not found, e.g. before the package is built, use a tlf template theme
-  # TODO use themes instead of extdata in later versions of tlf
+  reThemeFile <- system.file("themes", "template-theme.json", package = "tlf")
+  if (!isIncluded(reThemeFile, "")) {
+    return(tlf::loadThemeFromJson(reThemeFile))
+  }
+  # Use extdata, in case the old tlf version is installed and used
   return(tlf::loadThemeFromJson(system.file("extdata", "template-theme.json", package = "tlf")))
 }
 reEnv$theme <- getDefaultRETheme()
@@ -218,7 +222,6 @@ getStatisticsFromType <- function(statisticsType) {
       rangeCaption = "mean \u00b1 SD range"
     ))
   }
-  # TODO : define geometric mean in tlf !
   return(list(
     y = "geomean",
     ymin = "geomeanDividedBySD",

--- a/R/task-results.R
+++ b/R/task-results.R
@@ -34,10 +34,8 @@ TaskResults <- R6::R6Class(
       if (isEmpty(self$plot)) {
         return()
       }
-      # TODO once every plot will use tlf, deprecate the condition for null values
       self$plot <- updatePlotDimensions(self$plot)
       # Use same dpi as RE environment settings to display correct point size
-      # TODO: To remove after implementation in tlf
       if (requireNamespace("showtext", quietly = TRUE)) {
         currentDPI <- showtext::showtext_opts()$dpi
         showtext::showtext_opts(dpi = reEnv$defaultPlotFormat$dpi)
@@ -51,7 +49,6 @@ TaskResults <- R6::R6Class(
         units = self$plot$plotConfiguration$export$units %||% reEnv$defaultPlotFormat$units
       )
       # Revert showtext settings
-      # TODO: To remove after implementation in tlf
       if (requireNamespace("showtext", quietly = TRUE)) {
         showtext::showtext_opts(dpi = currentDPI)
       }

--- a/R/task.R
+++ b/R/task.R
@@ -91,8 +91,6 @@ Task <- R6::R6Class(
       if (isEmpty(inputsToCheck)) {
         return(TRUE)
       }
-
-      # TODO: update after PR about logging
       tryCatch(
         {
           validateFileExists(inputsToCheck, nullAllowed = TRUE)

--- a/R/utilities-demography.R
+++ b/R/utilities-demography.R
@@ -884,7 +884,7 @@ plotDemographyRange <- function(data,
                                 plotConfiguration = NULL,
                                 parameterClass = "numeric") {
   mapLabels <- tlf:::.getAesStringMapping(dataMapping)
-  # TODO: once range plots included in tlf, switch to range plots
+  
   vpcPlotConfiguration <- plotConfiguration %||% switch(parameterClass,
     "character" = tlf::BoxWhiskerPlotConfiguration$new(
       data = data,

--- a/R/utilities-goodness-of-fit.R
+++ b/R/utilities-goodness-of-fit.R
@@ -249,7 +249,7 @@ getResiduals <- function(observedData,
 
   timeMatchedData <- as.numeric(sapply(as.data.frame(abs(obsTimeMatrix - simTimeMatrix)), which.min))
 
-  # TODO: issue #942, once implemented use ospsuite residuals calculation
+  # Issue #942, once implemented use ospsuite residuals calculation
   residualValues <- rep(NA, nrow(observedData))
   if (isIncluded(residualScale, ResidualScales$Logarithmic)) {
     residualValues <- log(observedData[, "Concentration"]) - log(simulatedData[timeMatchedData, "Concentration"])
@@ -579,8 +579,7 @@ plotMeanTimeProfileLog <- function(simulatedData,
                                    metaData = NULL,
                                    dataMapping = NULL,
                                    plotConfiguration = NULL) {
-  # Remove 0 values from simulated and observed data
-  # TODO: use dplyr to refactor the selection
+  # Remove 0 values from simulated and observed data because of log scale
   simulatedData <- removeNegativeValues(simulatedData, dataMapping$y)
   observedData <- removeNegativeValues(observedData, dataMapping$y)
 
@@ -681,8 +680,7 @@ plotPopTimeProfileLog <- function(simulatedData,
                                   metaData = NULL,
                                   dataMapping = NULL,
                                   plotConfiguration = NULL) {
-  # Remove 0 values from simulated and observed data
-  # TODO: use dplyr to refactor the selection
+  # Remove 0 values from simulated and observed data because of log plots
   simulatedData <- removeNegativeValues(simulatedData, dataMapping$y)
   simulatedData <- removeNegativeValues(simulatedData, dataMapping$ymin)
   simulatedData <- removeNegativeValues(simulatedData, dataMapping$ymax)
@@ -1044,7 +1042,7 @@ getResidualsPlotResults <- function(timeRange, residualsData, metaDataFrame, str
     goodnessOfFitPlots[[resultId]] <- obsVsPredPlot
     goodnessOfFitCaptions[[resultId]] <- getGoodnessOfFitCaptions(structureSet, "obsVsPred", "linear", settings)
 
-    # TODO: update after tlf is robust enough when 0 is in log plots (tlf issue #369)
+    # tlf issue #369
     selectedLogData <- selectedResidualsData$Simulated > 0 & selectedResidualsData$Observed > 0
     if (sum(selectedLogData) > 0) {
       # In log scale, identity line is 1 instead of 0

--- a/R/utilities-mpi-error-handling.R
+++ b/R/utilities-mpi-error-handling.R
@@ -101,8 +101,6 @@ updateIndividualParametersOnCores <- function(individualParameters) {
   return(invisible())
 }
 
-# TODO: Functions starting with verify should be renamed, refactored and placed within error-checks.R
-
 #' @title verifySimulationRunSuccessful
 #' @description Check that all cores ran simulation successfully
 #' @param simulationRunSuccess logical vector indicating success of simulation run on all cores

--- a/R/utilities-plots.R
+++ b/R/utilities-plots.R
@@ -266,7 +266,6 @@ addLineBreakToCaption <- function(captions, maxLines = reEnv$maxLinesPerLegendCa
       next
     }
     # dashes and spaces provides preferential sites for line breaks
-    # TODO: improve the preferental site using input arguments
     dashSplits <- as.numeric(gregexpr(pattern = "-", captions[captionIndex])[[1]])
     spaceSplits <- as.numeric(gregexpr(pattern = " ", captions[captionIndex])[[1]])
     possibleSplits <- sort(c(dashSplits[dashSplits > 0], spaceSplits[spaceSplits > 0]))
@@ -881,7 +880,6 @@ getDefaultPropertiesFromTheme <- function(plotName,
 #' In time profiles, legends are merged into one unique legend
 #' The displayed legend is stored in the `plotObject` within the color guide field `override.aes`.
 #' This function simply gets the list from that field for updating the current legend
-#' TODO: create and export that function in `{tlf}` package
 #' @param plotObject A ggplot object
 #' @return A list of aesthetic values
 #' @keywords internal
@@ -897,8 +895,6 @@ getLegendAesOverride <- function(plotObject) {
 #' @title addLLOQLegend
 #' @description
 #' Add LLOQ displayed legend to the legend of a `plotObject`
-#' TODO: create and export that function in `{tlf}` package
-#' Fix coloring issues
 #' @param plotObject A ggplot object
 #' @param captions Current observed data captions for which lloq legend is needed
 #' @param prefix Prefix for legend

--- a/R/utilities-qualification.R
+++ b/R/utilities-qualification.R
@@ -18,11 +18,7 @@ loadQualificationWorkflow <- function(workflowFolder, configurationPlanFile) {
 
   outputsDataframe <- getOutputsFromConfigurationPlan(configurationPlan = configurationPlan)
 
-  # TODO outputs and pk parameters may need to be defined
-  # Either as part of simulationSets or as a settings for the task
-  # Currently, no output is saved as simulationResults
   simulationSets <- list()
-
   # Display a nice progress bar
   t0 <- tic()
   logInfo(paste0("Loading Simulations onto ", highlight("Qualification Workflow")))
@@ -287,12 +283,6 @@ getOutputsFromGOFMergedPlotsConfiguration <- function(plot) {
   }
   return(unique(paths))
 }
-
-
-# Vector of allowable plot types in configuration plan.
-# TODO deprecate vector using enum ConfigurationPlots
-QualificationPlotTypes <- c("GOFMergedPlots", "ComparisonTimeProfilePlots", "DDIRatioPlots", "TimeProfile")
-
 
 #' @title extractNameAndUnit
 #' @description Returns a named list with two entries (name, unit) corresponding to the name and unit

--- a/R/utilities-ratio-comparison.R
+++ b/R/utilities-ratio-comparison.R
@@ -494,7 +494,6 @@ getPKRatioSummaryFromMCSampling <- function(pkData, referencePKData, simulationS
 #' @import ggplot2
 ratioBoxplot <- function(data,
                          plotConfiguration = NULL) {
-  # TODO: create new molecule plot for this
   ratioPlot <- tlf::initializePlot(plotConfiguration)
   aestheticValues <- tlf:::.getAestheticValuesFromConfiguration(
     n = 1,

--- a/R/utilities-task.R
+++ b/R/utilities-task.R
@@ -59,8 +59,6 @@ AllAvailableTasks <- c(
 #'
 activateWorkflowTasks <- function(workflow, tasks = workflow$getAllTasks()) {
   validateIsOfType(workflow, "Workflow")
-
-  # TODO: update once renamed
   validateIsIncludedAndLog(tasks, workflow$getAllTasks(), groupName = "names of available workflow tasks")
 
   for (task in tasks) {
@@ -92,8 +90,6 @@ activateWorkflowTasks <- function(workflow, tasks = workflow$getAllTasks()) {
 #'
 inactivateWorkflowTasks <- function(workflow, tasks = workflow$getAllTasks()) {
   validateIsOfType(workflow, "Workflow")
-
-  # TODO: Update once the function name is updated
   validateIsIncludedAndLog(tasks, workflow$getAllTasks(), groupName = "names of available workflow tasks")
 
   for (task in tasks) {
@@ -833,11 +829,11 @@ addUserDefinedTask <- function(workflow,
   argumentNames <- names(formals(taskFunction))
   if (isOfType(workflow, "MeanModelWorkflow")) {
     # PlotTask arguments
-    # TODO: updated once renamed
     validateIsIncludedAndLog(
-      c("structureSet", "settings"), argumentNames,
+      c("structureSet", "settings"), 
+      argumentNames, 
       groupName = "Task function arguments"
-    )
+      )
 
     workflow$userDefinedTasks <- c(
       workflow$userDefinedTasks,
@@ -857,9 +853,9 @@ addUserDefinedTask <- function(workflow,
 
   if (isOfType(workflow, "PopulationWorkflow")) {
     # PopulationPlotTask arguments
-    # TODO: update once renamed
     validateIsIncludedAndLog(
-      c("structureSets", "settings", "workflowType", "xParameters", "yParameters"), argumentNames,
+      c("structureSets", "settings", "workflowType", "xParameters", "yParameters"), 
+      argumentNames,
       groupName = "Task function arguments"
     )
 
@@ -919,7 +915,6 @@ loadQualificationTimeProfilesTask <- function(workflow, configurationPlan) {
     getTaskResults = taskFunction,
     nameTaskResults = nameFunction,
     inputFolder = defaultTaskOutputFolders$simulate,
-    # TODO: add observed data
     inputs = inputFiles,
     workflowFolder = workflow$workflowFolder,
     active = active,
@@ -960,7 +955,6 @@ loadGOFMergedTask <- function(workflow, configurationPlan) {
     getTaskResults = taskFunction,
     nameTaskResults = nameFunction,
     inputFolder = defaultTaskOutputFolders$simulate,
-    # TODO: add observed data
     inputs = inputFiles,
     workflowFolder = workflow$workflowFolder,
     active = active,
@@ -1009,7 +1003,6 @@ loadQualificationComparisonTimeProfileTask <- function(workflow, configurationPl
     getTaskResults = taskFunction,
     nameTaskResults = nameFunction,
     inputFolder = defaultTaskOutputFolders$simulate,
-    # TODO: add observed data
     inputs = inputFiles,
     workflowFolder = workflow$workflowFolder,
     active = active,
@@ -1051,7 +1044,6 @@ loadPlotPKRatioTask <- function(workflow, configurationPlan) {
     getTaskResults = taskFunction,
     nameTaskResults = nameFunction,
     inputFolder = defaultTaskOutputFolders$simulate,
-    # TODO: add observed data
     inputs = inputFiles,
     workflowFolder = workflow$workflowFolder,
     active = active,
@@ -1118,7 +1110,6 @@ loadPlotDDIRatioTask <- function(workflow, configurationPlan) {
     getTaskResults = taskFunction,
     nameTaskResults = nameFunction,
     inputFolder = defaultTaskOutputFolders$simulate,
-    # TODO: add observed data
     inputs = inputFiles,
     workflowFolder = workflow$workflowFolder,
     active = active,

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,5 +1,3 @@
-# TODO: add these functions to tlf
-
 #' @title geomean
 #' @description
 #' Calculate the geometric mean

--- a/man/addLLOQLegend.Rd
+++ b/man/addLLOQLegend.Rd
@@ -18,7 +18,5 @@ A list of aesthetic values
 }
 \description{
 Add LLOQ displayed legend to the legend of a `plotObject`
-TODO: create and export that function in `{tlf}` package
-Fix coloring issues
 }
 \keyword{internal}

--- a/man/getLegendAesOverride.Rd
+++ b/man/getLegendAesOverride.Rd
@@ -16,6 +16,5 @@ A list of aesthetic values
 In time profiles, legends are merged into one unique legend
 The displayed legend is stored in the `plotObject` within the color guide field `override.aes`.
 This function simply gets the list from that field for updating the current legend
-TODO: create and export that function in `{tlf}` package
 }
 \keyword{internal}


### PR DESCRIPTION
34 TODOs were identified and removed

- [x] `configuration-plan.R` resizing of the input was fixed in [`tlf`](https://github.com/Open-Systems-Pharmacology/TLF-Library/blob/6bafc92b5539fe381640c4d0d623fdd83406ca18/R/utilities-background.R#L381)
- [x] `error-checks.R` replace the function name can be removed (logging wrapper around function used instead)
- [x] `gof-plot-task.R` group outputs in goodness of fit plots by unique `groupID` once introduced - now described in issue #1188
- [x] `qualification-gof.R` handling of LLOQ is already described in a dedicated issue #1043 
- [x] `qualification-pk-ratio.R` now described in #1192
- [x] `qualification-time-profile.R` error handling now described in issue #1189
- [x] `reportingengine-env.R` in case re theme is not found use tlf theme from themes folder (fixed in current PR)
- [x]  `reportingengine-env.R` now described in #1192
- [x] `task.R` obsolete, no update needed with `logCatch()`
- [x] `task-results.R` deprecate the condition for null values is obsolete
- [x] `task-results.R` `{showtext}` hook may be redundant but ensures tlf settings are not altered
- [x] `utilities-demography.R` now described in #1192
- [x] `utilities-goodness-of-fit.R` already described in issue #942
- [x] `utilities-goodness-of-fit.R` use dplyr to refactor the selection not necessary
- [x]  `utilities-goodness-of-fit.R` use dplyr to refactor the selection not necessary
- [x]  `utilities-goodness-of-fit.R` already described in tlf issue [#369](https://github.com/Open-Systems-Pharmacology/TLF-Library/issues/369)
- [x] `utilities-mpi-error-handling.R` now described in #1190
- [x] `utilities-plots.R` obsolete since line break algo works appropriately
- [x] `utilities-plots.R` now described in #1192
- [x] `utilities-plots.R` now described in #1192
- [x] `utilities-qualification.R` obsolete outputs and pk parameters are defined in the loop
- [x] `utilities-qualification.R` `QualificationPlotTypes` not used and removed in current PR
- [x] `utilities-ratio-comparison.R` now described in #1192
- [x] `utilities-task.R` obsolete, no update needed with `logCatch()`
- [x] `utilities-task.R` obsolete, no update needed with `logCatch()`
- [x] `utilities-task.R` obsolete, no update needed with `logCatch()`
- [x] `utilities-task.R` obsolete, no update needed with `logCatch()`
- [x] `utilities-task.R` now described in #1191
- [x] `utilities-task.R` now described in #1191
- [x] `utilities-task.R` now described in #1191
- [x] `utilities-task.R` now described in #1191
- [x] `utilities-task.R` now described in #1191
- [x] `utils.R` now described in #1192