### PR TITLE
Fixes #1274 Prevent crash of 0 simulated values in log scale

### DIFF
--- a/R/messages.R
+++ b/R/messages.R
@@ -296,6 +296,13 @@ messages <- list(
       paste0(highlight(unique(values)), collapse = "', '"), "'."
     )
   },
+  warningLogScaleIssue = function(output) {
+    paste0(
+      "Plot scale is logarithmic, however all values from simulated output '", 
+      highlight(output), "' were 0."
+    )
+  },
+  
   #----- Info messages ----
   runStarting = function(runName, subRun = NULL) {
     if (is.null(subRun)) {

--- a/R/qualification-comparison-time-profile.R
+++ b/R/qualification-comparison-time-profile.R
@@ -124,7 +124,14 @@ addOutputToComparisonTimeProfile <- function(outputMapping, simulationDuration, 
     molWeight = molWeight
   )
   simulatedValues <- simulatedValues[selectedTimeValues]
-
+  logScaleIssue <- all(simulatedValues == 0, isIncluded(axesProperties$y$scale, "log")) 
+  if(logScaleIssue){
+    warning(messages$warningLogScaleIssue(outputMapping$Output), call. = FALSE)
+    # Set the first value to 1 to avoid log scale issue
+    # Since this only affect one value, no line will plotted
+    simulatedValues[1] <- 1
+  }
+  
   # Add simulated values to plot
   plotObject <- tlf::addLine(
     x = simulatedTime,


### PR DESCRIPTION
Provides a warning for such a case:

```
! Warning	Plot scale is logarithmic, however all values from simulated output 'Organism|PeripheralVenousBlood|Dextrorphan-O-glucuronide|Plasma (Peripheral Venous Blood)' were 0.
Configuration Plan Information:
SectionId: 301
Title: Quinidine-Dextromethorphan-DDI
SimulationDuration: 60
TimeUnit: h
OutputMappings: list(...)
PlotNumber: 1 (json numbering starting at 0);  2 (actual plot index)
```