### PR TITLE
Fixes #1285 skip DDI plots when no non missing data are available

### DIFF
--- a/R/messages.R
+++ b/R/messages.R
@@ -195,6 +195,18 @@ messages <- list(
   warningPKParameterNotEnoughData = function(pkParameter, path) {
     paste0(highlight(pkParameter), " for ", highlight(path), ": not enough available data to perform plot.")
   },
+  warningDDINotPlotted = function(title, pkParameter, plotType, captionSuffix = NULL) {
+    subunitMessage <- ifelse(
+      is.null(captionSuffix),
+      "",
+      paste0("' for subunit '", highlight(captionSuffix))
+    )
+    return(paste0(
+      "DDI plot '", highlight(title), subunitMessage,
+      "' of ", plotType, " '", highlight(pkParameter),
+      "' ratios was skipped because no data was available."
+    ))
+  },
   warningApplicationsBeforeTimeOffset = function(applicationLength, timeRanges, timeUnit, timeOffset, simulationSetName) {
     paste0(
       highlight(applicationLength), " application(s) at ", highlight(timeRanges), " ", timeUnit,
@@ -298,11 +310,11 @@ messages <- list(
   },
   warningLogScaleIssue = function(output) {
     paste0(
-      "Plot scale is logarithmic, however all values from simulated output '", 
+      "Plot scale is logarithmic, however all values from simulated output '",
       highlight(output), "' were lower or equal to 0."
     )
   },
-  
+
   #----- Info messages ----
   runStarting = function(runName, subRun = NULL) {
     if (is.null(subRun)) {

--- a/R/qualification-ddi.R
+++ b/R/qualification-ddi.R
@@ -276,6 +276,9 @@ getSmartZoomLimits <- function(dataVector, residualsVsObserved = FALSE) {
 #' @keywords internal
 generateDDIQualificationDDIPlot <- function(ddiPlotData, delta) {
   ddiData <- na.omit(ddiPlotData$ddiPlotDataframe)
+  if (isEmpty(ddiData)) {
+    return(NULL)
+  }
 
   residualsVsObserved <- ddiPlotTypeSpecifications[[ddiPlotData$axesSettings$plotType]]$residualsVsObservedFlag
 
@@ -397,6 +400,19 @@ getDDISection <- function(dataframe, metadata, sectionID, idPrefix, captionSuffi
 
       plotID <- defaultFileNames$resultID(idPrefix, "ddi_ratio_plot", pkParameter, plotType)
       ddiPlot <- generateDDIQualificationDDIPlot(plotDDIData, delta = metadata$guestDelta[[pkParameter]])
+      if (isEmpty(ddiPlot)) {
+        warning(
+          messages$warningDDINotPlotted(
+            title = plotDDIData$plotSettings$Title,
+            pkParameter = pkParameter,
+            plotType = plotType,
+            # Caption suffix indicates for which subunit, DDI plot is skipped
+            captionSuffix = captionSuffix
+          ),
+          call. = FALSE
+        )
+        next
+      }
       ddiPlotCaption <- getDDIPlotCaption(
         title = metadata$title,
         subPlotCaption = captionSuffix,


### PR DESCRIPTION
@Yuri05 
Here is an example of message when skipping the plot
```r
! Warning	DDI plot 'Pgp DDI' for subunit 'Victim: Digoxin' of predictedVsObserved 'AUC_tEnd' ratios was skipped because no data was available
```