### PR TITLE
Fixes #1343 remove redundant data filter

### DIFF
--- a/R/qualification-comparison-time-profile.R
+++ b/R/qualification-comparison-time-profile.R
@@ -183,8 +183,8 @@ addOutputToComparisonTimeProfile <- function(outputMapping, simulationDuration, 
 
       plotObject <- tlf::addErrorbar(
         x = observedTime,
-        ymin = observedError$ymin[selectedObservedTimeValues],
-        ymax = observedError$ymax[selectedObservedTimeValues],
+        ymin = observedError$ymin,
+        ymax = observedError$ymax,
         caption = prettyCaption(paste(outputMapping$Caption, "Observed Data"), plotObject),
         color = outputMapping$Color,
         size = outputMapping$Size,


### PR DESCRIPTION
The filter is already applied before creating ymin and ymax. In this case, since the filter was removing the first data point, it shifted all the error bars