### PR TITLE
Add MoBiPortableFolder argument to startQualificationRunner

### DIFF
--- a/R/utilities-qualification.R
+++ b/R/utilities-qualification.R
@@ -499,6 +499,10 @@ getPlotSettings <- function(plotSettingsFromConfigurationPlot) {
 #' @param pkSimPortableFolder Folder where PK-Sim is located.
 #' If not specified, installation path will be read from the registry (available only in case of full **non-portable** installation).
 #' This option is **MANDATORY** for the portable version of PK-Sim.
+#' @param moBiPortableFolder Folder where MoBi is located.
+#' If not specified, installation path will be read from the registry (available only in case of full **non-portable** installation).
+#' This option is **MANDATORY** for the portable version of MoBi.
+#' Only required for qualification plans including MoBi projects.
 #' @param configurationPlanName Name of the configuration plan to be generated. Default is `"report-configuration-plan"`
 #' @param overwrite Logical defining if the contents of the output folder will be deleted, even if it not empty. Default is false.
 #' @param logFile Full path of log file where log output will be written. A log file will not be created if this value is not provided.
@@ -511,6 +515,7 @@ startQualificationRunner <- function(
   qualificationPlanFile,
   outputFolder,
   pkSimPortableFolder = NULL,
+  moBiPortableFolder = NULL,
   configurationPlanName = NULL,
   overwrite = TRUE,
   logFile = NULL,
@@ -524,6 +529,7 @@ startQualificationRunner <- function(
 
   options <- c(
     ifNotNull(pkSimPortableFolder, paste0('-p "', pkSimPortableFolder, '"')),
+    ifNotNull(moBiPortableFolder, paste0('-m "', moBiPortableFolder, '"')),
     ifNotNull(
       configurationPlanName,
       paste0('-n "', configurationPlanName, '"')

--- a/inst/extdata/qualification-workflow-template.R
+++ b/inst/extdata/qualification-workflow-template.R
@@ -4,6 +4,10 @@
 #' @param pkSimPortableFolder Folder where PK-Sim is located.
 #' If not specified, installation path will be read from the registry (available only in case of full **non-portable** installation).
 #' This option is **MANDATORY** for the portable version of PK-Sim.
+#' @param moBiPortableFolder Folder where MoBi is located.
+#' If not specified, installation path will be read from the registry (available only in case of full **non-portable** installation).
+#' This option is **MANDATORY** for the portable version of MoBi.
+#' Only required for qualification plans including MoBi projects.
 #' @param createWordReport Logical defining if a `docx` version of the report should also be created.
 #' Note that `pandoc` installation is required for this feature
 #' [https://github.com/Open-Systems-Pharmacology/OSPSuite.ReportingEngine/wiki/Installing-pandoc]
@@ -27,6 +31,7 @@
 #' 
 createQualificationReport <- function(qualificationRunnerFolder,
                                       pkSimPortableFolder = NULL,
+                                      moBiPortableFolder = NULL,
                                       createWordReport = TRUE,
                                       maxSimulationsPerCore = NULL,
                                       versionInfo = NULL,
@@ -104,6 +109,7 @@ createQualificationReport <- function(qualificationRunnerFolder,
     qualificationPlanFile = qualificationPlanFile,
     outputFolder = reInputFolder,
     pkSimPortableFolder = pkSimPortableFolder,
+    moBiPortableFolder = moBiPortableFolder,
     configurationPlanName = configurationPlanName,
     overwrite = overwrite,
     logFile = logFile,

--- a/man/startQualificationRunner.Rd
+++ b/man/startQualificationRunner.Rd
@@ -9,6 +9,7 @@ startQualificationRunner(
   qualificationPlanFile,
   outputFolder,
   pkSimPortableFolder = NULL,
+  moBiPortableFolder = NULL,
   configurationPlanName = NULL,
   overwrite = TRUE,
   logFile = NULL,
@@ -26,6 +27,11 @@ startQualificationRunner(
 \item{pkSimPortableFolder}{Folder where PK-Sim is located.
 If not specified, installation path will be read from the registry (available only in case of full \strong{non-portable} installation).
 This option is \strong{MANDATORY} for the portable version of PK-Sim.}
+
+\item{moBiPortableFolder}{Folder where MoBi is located.
+If not specified, installation path will be read from the registry (available only in case of full \strong{non-portable} installation).
+This option is \strong{MANDATORY} for the portable version of MoBi.
+Only required for qualification plans including MoBi projects.}
 
 \item{configurationPlanName}{Name of the configuration plan to be generated. Default is \code{"report-configuration-plan"}}
 


### PR DESCRIPTION
Fixes #1373

In V13 MoBi will support qualification workflows. We need a way to specify to the runner the location of a portable MoBi that should be used in a similar way to how PKSimPortable is supported.

## Changes

`startQualificationRunner()` gains a `moBiPortableFolder` argument that mirrors the existing `pkSimPortableFolder` handling one-to-one. It is passed to `QualificationRunner.exe` via its `-m` / `--mobi` option, which — like `-p` / `--pksim` — falls back to reading the installation path from the registry when omitted, so the argument is only mandatory for a portable MoBi.

- `R/utilities-qualification.R` — new `moBiPortableFolder = NULL` argument, emitted as `-m "<folder>"` using the same `ifNotNull()` idiom as `-p`.
- `inst/extdata/qualification-workflow-template.R` — `createQualificationReport()` accepts and forwards the argument.
- `man/startQualificationRunner.Rd` — regenerated with roxygen2 7.3.3, matching `RoxygenNote` in DESCRIPTION.

## Notes for review

- **Argument position is a judgement call.** `moBiPortableFolder` sits immediately after `pkSimPortableFolder` to keep the two portable-folder arguments together, which shifts `configurationPlanName` and subsequent arguments by one position. All call sites in this repo use named arguments and the vignette only shows the three required positional ones, so this seemed safe — happy to append it last instead if strict positional compatibility is preferred.
- **No NEWS.md entry**, as the issue carries the `dev-only` label.
- **Not included, flagging for the wider V13 work:** when the runner drives a MoBi project it forwards `--pkSim <PKSimInstallationFolder>` to `MoBi.CLI.exe` so MoBi can reach PK-Sim services, but only when `-p` was explicitly passed ([QualificationEngine.cs L76-79](https://github.com/Open-Systems-Pharmacology/QualificationRunner/blob/develop/src/QualificationRunner.Core/Services/QualificationEngine.cs#L76-L79)). A portable-MoBi qualification will therefore usually need *both* `moBiPortableFolder` and `pkSimPortableFolder` set. That is runner-side behaviour so it is not documented here, but it is likely to be the first support question.
- **Unrelated roxygen drift left untouched.** Regenerating the docs also rewrites 13 R6 `Rd` files (`CalculatePKParametersTask`, `GofPlotTask`, `GofTaskSettings`, `MeanModelWorkflow`, `PlotTask`, `PopulationPlotTask`, `PopulationSensitivityAnalysisTask`, `PopulationSimulationSet`, `PopulationWorkflow`, `QualificationTask`, `QualificationWorkflow`, `SensitivityAnalysisTask`, `SimulationTask`), where roxygen 7.3.3 hyperlinks the "Super classes" cross-references as `\link[ospsuite.reportingengine:Task]{...}` instead of the plain `\code{...}` currently committed. That drift predates this change, so I reverted those files to keep the diff surgical. It may be worth a separate housekeeping commit.

## Testing

There is no existing test coverage for `startQualificationRunner()` (it shells out to an external executable), so none was added. Both edited R files parse cleanly, and `roxygen2::roxygenise()` leaves the working tree clean, confirming the committed `Rd` matches generated output.
